### PR TITLE
fix: albumchat like순서로 데이터 전달 오류 해결

### DIFF
--- a/backend/src/main/java/org/cosmic/backend/domain/playList/repositorys/AlbumRepository.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/playList/repositorys/AlbumRepository.java
@@ -28,7 +28,12 @@ public interface AlbumRepository extends JpaRepository<Album,Long> {
     @Query("SELECT a FROM Album a LEFT JOIN a.albumChatComments acc GROUP BY a.albumId ORDER BY COUNT(acc) DESC,a.albumId ASC ")
     Page<Album> findAlbumsOrderByCommentCount(Pageable pageable);
 
-    @Query("SELECT a FROM Album a LEFT JOIN a.albumLike al GROUP BY a.albumId ORDER BY COUNT(al) DESC, a.albumId ASC ")
+    @Query(value = "SELECT a.album_id, album_cover, created_date, genre, spotify_album_id, title, artist_id\n" +
+            "FROM album a\n" +
+            "LEFT JOIN album_like al\n" +
+            "ON a.album_id=al.album_id\n" +
+            "GROUP BY a.album_id\n" +
+            "ORDER BY COUNT(al) DESC, a.album_id", nativeQuery = true)
     Page<Album> findAlbumsOrderByAlbumLikeCount(Pageable pageable);
 
     Optional<Album> findBySpotifyAlbumId(String spotifyAlbumId);


### PR DESCRIPTION
좋아요 순으로 정렬이 되지 않던 문제 해결했습니다.