### PR TITLE
refactor/backend/like-dto

### DIFF
--- a/backend/src/main/java/org/cosmic/backend/domain/albumChat/apis/AlbumChatCommentApi.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/albumChat/apis/AlbumChatCommentApi.java
@@ -64,11 +64,11 @@ public class AlbumChatCommentApi {
       @Parameter(description = "앨범 id")
       @PathVariable("spotifyAlbumId") String spotifyAlbumId,
       @Parameter(description = "댓글 정렬", required = false)
-      @RequestParam String sorted,
+      @RequestParam(required = false, defaultValue = "recent") String sorted,
       @Parameter(description = "페이지 수")
-      @RequestParam Integer page,
+      @RequestParam(required = false, defaultValue = "0") Integer page,
       @Parameter(description = "제공량")
-      @RequestParam Integer limit
+      @RequestParam(required = false, defaultValue = "5") Integer limit
   ) {
     return ResponseEntity.ok(
         commentService.getAlbumChatComment(spotifyAlbumId, sorted, page, limit));

--- a/backend/src/main/java/org/cosmic/backend/domain/albumChat/apis/AlbumChatCommentLikeApi.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/albumChat/apis/AlbumChatCommentLikeApi.java
@@ -57,7 +57,7 @@ public class AlbumChatCommentLikeApi {
    * @return 좋아요 목록을 포함한 {@link ResponseEntity}
    * @throws NotFoundAlbumChatCommentException 앨범챗 댓글을 찾을 수 없을 때 발생합니다.
    */
-  @GetMapping("/album/{albumId}/comment/{albumChatCommentId}/commentLike")
+  @GetMapping("/album/{spotifyAlbumId}/comment/{albumChatCommentId}/commentLike")
   @ApiResponse(responseCode = "404", description = "Not Found AlbumChatComment")
   @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
       array = @ArraySchema(schema = @Schema(implementation = AlbumChatCommentLikeDetail.class))))

--- a/backend/src/main/java/org/cosmic/backend/domain/albumChat/apis/AlbumChatCommentLikeApi.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/albumChat/apis/AlbumChatCommentLikeApi.java
@@ -7,26 +7,28 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.cosmic.backend.domain.albumChat.applications.AlbumChatCommentLikeService;
+import org.cosmic.backend.domain.albumChat.applications.AlbumChatCommentService;
+import org.cosmic.backend.domain.albumChat.dtos.comment.AlbumChatCommentDetail;
 import org.cosmic.backend.domain.albumChat.dtos.commentlike.AlbumChatCommentLikeDetail;
-import org.cosmic.backend.domain.post.dtos.Post.PostAndCommentsDetail;
+import org.cosmic.backend.domain.albumChat.exceptions.NotFoundAlbumChatCommentException;
 import org.cosmic.backend.globals.annotations.ApiCommonResponses;
+import org.cosmic.backend.globals.exceptions.NotFoundException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-
-import org.cosmic.backend.domain.albumChat.exceptions.ExistCommentLikeException;
-import org.cosmic.backend.domain.albumChat.exceptions.NotFoundAlbumChatCommentException;
-import org.cosmic.backend.domain.albumChat.exceptions.NotFoundCommentLikeException;
-import org.cosmic.backend.domain.playList.exceptions.NotFoundUserException;
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * <p>AlbumChatCommentLikeApi 클래스는 앨범 챗 댓글에 대한 좋아요 기능을 처리하는 API를 정의합니다.</p>
  *
  * <p>이 API는 특정 댓글에 대한 좋아요 조회, 생성, 삭제 기능을 제공합니다.</p>
- *
  */
 @RestController
 @RequestMapping("/api/")
@@ -34,47 +36,65 @@ import java.util.List;
 @Tag(name = "앨범 챗 관련 API", description = "앨범 챗 댓글/대댓글/좋아요 제공")
 public class AlbumChatCommentLikeApi {
 
-    private final AlbumChatCommentLikeService likeService;
+  private final AlbumChatCommentLikeService likeService;
+  private final AlbumChatCommentService albumChatCommentService;
 
-    /**
-     * <p>AlbumChatCommentLikeApi 생성자입니다.</p>
-     *
-     * @param likeService 앨범 챗 댓글 좋아요 서비스를 처리하는 서비스 객체
-     */
-    public AlbumChatCommentLikeApi(AlbumChatCommentLikeService likeService) {
-        this.likeService = likeService;
+  /**
+   * <p>AlbumChatCommentLikeApi 생성자입니다.</p>
+   *
+   * @param likeService 앨범 챗 댓글 좋아요 서비스를 처리하는 서비스 객체
+   */
+  public AlbumChatCommentLikeApi(AlbumChatCommentLikeService likeService,
+      AlbumChatCommentService albumChatCommentService) {
+    this.likeService = likeService;
+    this.albumChatCommentService = albumChatCommentService;
+  }
+
+  /**
+   * <p>특정 앨범의 앨범챗 댓글에 대한 좋아요 목록을 조회합니다.</p>
+   *
+   * @param albumChatCommentId 조회할 댓글 ID
+   * @return 좋아요 목록을 포함한 {@link ResponseEntity}
+   * @throws NotFoundAlbumChatCommentException 앨범챗 댓글을 찾을 수 없을 때 발생합니다.
+   */
+  @GetMapping("/album/{albumId}/comment/{albumChatCommentId}/commentLike")
+  @ApiResponse(responseCode = "404", description = "Not Found AlbumChatComment")
+  @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+      array = @ArraySchema(schema = @Schema(implementation = AlbumChatCommentLikeDetail.class))))
+  @Operation(summary = "댓글 좋아요 조회", description = "특정 앨범의 앨범챗 댓글의 좋아요 조회")
+  public ResponseEntity<List<AlbumChatCommentLikeDetail>> albumChatCommentLikeGetByAlbumChatCommentId(
+      @Parameter(description = "앨범챗 댓글 id")
+      @PathVariable Long albumChatCommentId) {
+    return ResponseEntity.ok(
+        likeService.getAlbumChatCommentLikeByAlbumChatCommentId(albumChatCommentId));
+  }
+
+  @PostMapping("/album/{spotifyAlbumId}/comment/{albumChatCommentId}/commentLike")
+  @ApiResponse(responseCode = "200", content = {
+      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          array = @ArraySchema(schema = @Schema(implementation = AlbumChatCommentDetail.class)))
+  })
+  @ApiResponse(responseCode = "404", description = "Not Found User or AlbumChat")
+  @Operation(summary = "앨범 챗 댓글 좋아요 API", description = "앨범 챗 특정 댓글에 대해 좋아요 혹은 좋아요를 취소합니다.")
+  public ResponseEntity<List<AlbumChatCommentDetail>> likeAlbumChat(
+      @PathVariable String spotifyAlbumId,
+      @PathVariable Long albumChatCommentId,
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "댓글 정렬", required = false)
+      @RequestParam(required = false, defaultValue = "recent") String sorted,
+      @Parameter(description = "페이지 수")
+      @RequestParam(required = false, defaultValue = "0") Integer page,
+      @Parameter(description = "제공량")
+      @RequestParam(required = false, defaultValue = "5") Integer limit
+  ) {
+    try {
+      likeService.unlike(albumChatCommentId, userId);
+    } catch (NotFoundException e) {
+      likeService.like(albumChatCommentId, userId);
     }
-
-    /**
-     * <p>특정 앨범의 앨범챗 댓글에 대한 좋아요 목록을 조회합니다.</p>
-     *
-     * @param albumChatCommentId 조회할 댓글 ID
-     * @return 좋아요 목록을 포함한 {@link ResponseEntity}
-     *
-     * @throws NotFoundAlbumChatCommentException 앨범챗 댓글을 찾을 수 없을 때 발생합니다.
-     */
-    @GetMapping("/album/{albumId}/comment/{albumChatCommentId}/commentLike")
-    @ApiResponse(responseCode = "404", description = "Not Found AlbumChatComment")
-    @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-            array = @ArraySchema(schema = @Schema(implementation = AlbumChatCommentLikeDetail.class))))
-    @Operation(summary = "댓글 좋아요 조회",description = "특정 앨범의 앨범챗 댓글의 좋아요 조회")
-    public ResponseEntity<List<AlbumChatCommentLikeDetail>> albumChatCommentLikeGetByAlbumChatCommentId(
-            @Parameter(description = "앨범챗 댓글 id")
-            @PathVariable Long albumChatCommentId) {
-        return ResponseEntity.ok(likeService.getAlbumChatCommentLikeByAlbumChatCommentId(albumChatCommentId));
-    }
-
-    @PostMapping("/album/{albumId}/comment/{albumChatCommentId}/commentLike")
-    @ApiResponse(responseCode = "200", content = {
-            @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = PostAndCommentsDetail.class))
-    })
-    @ApiResponse(responseCode = "404", description = "Not Found User or AlbumChat")
-    @Operation(summary = "앨범 챗 댓글 좋아요 API", description = "앨범 챗 특정 댓글에 대해 좋아요 혹은 좋아요를 취소합니다.")
-    public ResponseEntity<List<AlbumChatCommentLikeDetail>> likeAlbumChat(@PathVariable Long albumId,@PathVariable Long albumChatCommentId, @AuthenticationPrincipal Long userId) {
-        return ResponseEntity.ok(likeService.likeOrUnlikeAlbumChat(albumChatCommentId, userId));
-    }
-
+    return ResponseEntity.ok(
+        albumChatCommentService.getAlbumChatComment(spotifyAlbumId, sorted, page, limit));
+  }
 
 
 }

--- a/backend/src/main/java/org/cosmic/backend/domain/albumChat/apis/AlbumLikeApi.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/albumChat/apis/AlbumLikeApi.java
@@ -8,25 +8,25 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.cosmic.backend.domain.albumChat.applications.AlbumLikeService;
-import org.cosmic.backend.domain.albumChat.dtos.albumlike.AlbumChatAlbumLikeDetail;
 import org.cosmic.backend.domain.albumChat.exceptions.ExistAlbumLikeException;
 import org.cosmic.backend.domain.albumChat.exceptions.NotFoundAlbumChatException;
 import org.cosmic.backend.domain.playList.exceptions.NotFoundUserException;
-import org.cosmic.backend.domain.post.dtos.Post.PostAndCommentsDetail;
-import org.cosmic.backend.domain.post.exceptions.NotFoundLikeException;
+import org.cosmic.backend.domain.post.dtos.Post.AlbumDetail;
 import org.cosmic.backend.globals.annotations.ApiCommonResponses;
+import org.cosmic.backend.globals.exceptions.NotFoundException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * <p>AlbumLikeApi 클래스는 앨범 챗에서 특정 앨범에 대한 좋아요 기능을 제공하는 API를 정의합니다.</p>
  *
  * <p>이 API는 특정 앨범에 대한 좋아요 조회, 생성, 삭제 기능을 제공합니다.</p>
- *
  */
 @RestController
 @RequestMapping("/api")
@@ -34,55 +34,59 @@ import java.util.List;
 @Tag(name = "앨범 챗 관련 API", description = "앨범 챗 댓글/대댓글/좋아요 제공")
 public class AlbumLikeApi {
 
-    private final AlbumLikeService likeService;
+  private final AlbumLikeService likeService;
 
-    /**
-     * <p>AlbumLikeApi 생성자입니다.</p>
-     *
-     * @param likeService 앨범 챗 좋아요 서비스 객체
-     */
-    public AlbumLikeApi(AlbumLikeService likeService) {
-        this.likeService = likeService;
-    }
+  /**
+   * <p>AlbumLikeApi 생성자입니다.</p>
+   *
+   * @param likeService 앨범 챗 좋아요 서비스 객체
+   */
+  public AlbumLikeApi(AlbumLikeService likeService) {
+    this.likeService = likeService;
+  }
 
-    /**
-     * <p>특정 앨범의 앨범챗 좋아요 목록을 조회합니다.</p>
-     *
-     * @param albumId 조회할 앨범의 ID
-     * @return 좋아요 목록을 포함한 {@link ResponseEntity}
-     *
-     * @throws NotFoundAlbumChatException 앨범챗을 찾을 수 없을 때 발생합니다.
-     */
-    @GetMapping("/album/{albumId}/albumLike")
-    @ApiResponse(responseCode = "404", description = "Not Found AlbumChat")
-    @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-            array = @ArraySchema(schema = @Schema(implementation = AlbumChatAlbumLikeDetail.class))))
-    @Operation(summary = "앨범 좋아요 조회",description = "특정 앨범의 앨범챗의 좋아요 조회")
-    public ResponseEntity<List<AlbumChatAlbumLikeDetail>> searchAlbumChatAlbumLikeByAlbumId(
-            @Parameter(description = "유저 id")
-            @PathVariable Long albumId) {
-        return ResponseEntity.ok(likeService.getAlbumChatAlbumLikeByAlbumChatId(albumId));
-    }
+  /**
+   * <p>특정 앨범의 앨범챗 좋아요 목록을 조회합니다.</p>
+   *
+   * @param spotifyAlbumId 조회할 앨범의 ID
+   * @return 좋아요 목록을 포함한 {@link ResponseEntity}
+   * @throws NotFoundAlbumChatException 앨범챗을 찾을 수 없을 때 발생합니다.
+   */
+  @GetMapping("/album/{spotifyAlbumId}/albumLike")
+  @ApiResponse(responseCode = "404", description = "Not Found AlbumChat")
+  @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+      schema = @Schema(implementation = AlbumDetail.class)))
+  @Operation(summary = "앨범 좋아요 조회", description = "특정 앨범의 앨범챗의 좋아요 조회")
+  public ResponseEntity<AlbumDetail> searchAlbumChatAlbumLikeByAlbumId(
+      @Parameter(description = "유저 id")
+      @PathVariable String spotifyAlbumId) {
+    return ResponseEntity.ok(likeService.getAlbumChatAlbumLikeBySpotifyAlbumId(spotifyAlbumId));
+  }
 
-    /**
-     * <p>특정 앨범에 대한 새로운 앨범챗 좋아요를 생성합니다.</p>
-     *
-     * @param albumId 좋아요를 추가할 앨범의 ID
-     * @param userId 좋아요를 생성하는 사용자 ID (인증된 사용자)
-     * @return 생성된 좋아요 목록을 포함한 {@link ResponseEntity}
-     *
-     * @throws NotFoundUserException 사용자를 찾을 수 없을 때 발생합니다.
-     * @throws NotFoundAlbumChatException 앨범챗을 찾을 수 없을 때 발생합니다.
-     * @throws ExistAlbumLikeException 이미 존재하는 좋아요가 있을 때 발생합니다.
-     */
-    @PostMapping("/album/{albumId}/like")
-    @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-            array = @ArraySchema(schema = @Schema(implementation = AlbumChatAlbumLikeDetail.class))))
-    @ApiResponse(responseCode = "404", description = "Not Found User or album")
-    @Operation(summary = "앨범 좋아요 API", description = "앨범에 대해 좋아요 혹은 좋아요를 취소합니다.")
-    public ResponseEntity<List<AlbumChatAlbumLikeDetail>> likeAlbum(@PathVariable Long albumId, @AuthenticationPrincipal Long userId) {
-        return ResponseEntity.ok(likeService.likeOrUnlikeAlbum(albumId, userId));
+  /**
+   * <p>특정 앨범에 대한 새로운 앨범챗 좋아요를 생성합니다.</p>
+   *
+   * @param spotifyAlbumId 좋아요를 추가할 앨범의 ID
+   * @param userId         좋아요를 생성하는 사용자 ID (인증된 사용자)
+   * @return 생성된 좋아요 목록을 포함한 {@link ResponseEntity}
+   * @throws NotFoundUserException      사용자를 찾을 수 없을 때 발생합니다.
+   * @throws NotFoundAlbumChatException 앨범챗을 찾을 수 없을 때 발생합니다.
+   * @throws ExistAlbumLikeException    이미 존재하는 좋아요가 있을 때 발생합니다.
+   */
+  @PostMapping("/album/{spotifyAlbumId}/like")
+  @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+      array = @ArraySchema(schema = @Schema(implementation = AlbumDetail.class))))
+  @ApiResponse(responseCode = "404", description = "Not Found User or album")
+  @Operation(summary = "앨범 좋아요 API", description = "앨범에 대해 좋아요 혹은 좋아요를 취소합니다.")
+  public ResponseEntity<AlbumDetail> likeAlbum(@PathVariable String spotifyAlbumId,
+      @AuthenticationPrincipal Long userId) {
+    try {
+      likeService.unlike(spotifyAlbumId, userId);
+    } catch (NotFoundException e) {
+      likeService.like(spotifyAlbumId, userId);
     }
+    return ResponseEntity.ok(likeService.getAlbumChatAlbumLikeBySpotifyAlbumId(spotifyAlbumId));
+  }
 
 
 }

--- a/backend/src/main/java/org/cosmic/backend/domain/albumChat/applications/AlbumChatCommentLikeService.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/albumChat/applications/AlbumChatCommentLikeService.java
@@ -1,141 +1,81 @@
 package org.cosmic.backend.domain.albumChat.applications;
 
-import org.cosmic.backend.domain.albumChat.domains.AlbumChatComment;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.cosmic.backend.domain.albumChat.domains.AlbumChatCommentLike;
 import org.cosmic.backend.domain.albumChat.dtos.commentlike.AlbumChatCommentLikeDetail;
-import org.cosmic.backend.domain.albumChat.exceptions.ExistCommentLikeException;
 import org.cosmic.backend.domain.albumChat.exceptions.NotFoundAlbumChatCommentException;
-import org.cosmic.backend.domain.albumChat.exceptions.NotFoundCommentLikeException;
 import org.cosmic.backend.domain.albumChat.repositorys.AlbumChatCommentLikeRepository;
 import org.cosmic.backend.domain.albumChat.repositorys.AlbumChatCommentRepository;
 import org.cosmic.backend.domain.playList.exceptions.NotFoundUserException;
-import org.cosmic.backend.domain.post.entities.Post;
-import org.cosmic.backend.domain.post.entities.PostLike;
-import org.cosmic.backend.domain.post.exceptions.NotFoundPostException;
-import org.cosmic.backend.domain.user.domains.User;
 import org.cosmic.backend.domain.user.repositorys.UsersRepository;
+import org.cosmic.backend.globals.exceptions.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * <p>AlbumChatCommentLikeService 클래스는 앨범 챗 댓글에 대한 좋아요 기능을 관리하는 서비스 클래스입니다.</p>
  *
  * <p>이 서비스는 댓글에 대한 좋아요의 생성, 조회, 삭제 기능을 제공합니다.</p>
- *
  */
 @Service
 public class AlbumChatCommentLikeService {
 
-    private final AlbumChatCommentLikeRepository albumChatCommentLikeRepository;
-    private final UsersRepository usersRepository;
-    private final AlbumChatCommentRepository albumChatCommentRepository;
+  private final AlbumChatCommentLikeRepository albumChatCommentLikeRepository;
+  private final UsersRepository usersRepository;
+  private final AlbumChatCommentRepository albumChatCommentRepository;
 
-    /**
-     * <p>AlbumChatCommentLikeService 생성자입니다.</p>
-     *
-     * @param albumChatCommentLikeRepository 앨범 챗 댓글 좋아요 리포지토리
-     * @param usersRepository 사용자 리포지토리
-     * @param albumChatCommentRepository 앨범 챗 댓글 리포지토리
-     */
-    public AlbumChatCommentLikeService(AlbumChatCommentLikeRepository albumChatCommentLikeRepository,
-                                       UsersRepository usersRepository,
-                                       AlbumChatCommentRepository albumChatCommentRepository) {
-        this.albumChatCommentLikeRepository = albumChatCommentLikeRepository;
-        this.usersRepository = usersRepository;
-        this.albumChatCommentRepository = albumChatCommentRepository;
+  /**
+   * <p>AlbumChatCommentLikeService 생성자입니다.</p>
+   *
+   * @param albumChatCommentLikeRepository 앨범 챗 댓글 좋아요 리포지토리
+   * @param usersRepository                사용자 리포지토리
+   * @param albumChatCommentRepository     앨범 챗 댓글 리포지토리
+   */
+  public AlbumChatCommentLikeService(AlbumChatCommentLikeRepository albumChatCommentLikeRepository,
+      UsersRepository usersRepository,
+      AlbumChatCommentRepository albumChatCommentRepository) {
+    this.albumChatCommentLikeRepository = albumChatCommentLikeRepository;
+    this.usersRepository = usersRepository;
+    this.albumChatCommentRepository = albumChatCommentRepository;
+  }
+
+  /**
+   * <p>특정 앨범챗 댓글에 대한 좋아요 목록을 조회합니다.</p>
+   *
+   * @param albumChatCommentId 조회할 댓글 ID
+   * @return 좋아요 목록을 포함한 리스트
+   * @throws NotFoundAlbumChatCommentException 앨범챗 댓글을 찾을 수 없을 때 발생합니다.
+   */
+  public List<AlbumChatCommentLikeDetail> getAlbumChatCommentLikeByAlbumChatCommentId(
+      Long albumChatCommentId) {
+    if (albumChatCommentRepository.findById(albumChatCommentId).isEmpty()) {
+      throw new NotFoundAlbumChatCommentException();
     }
+    return albumChatCommentLikeRepository.findByAlbumChatComment_AlbumChatCommentId(
+            albumChatCommentId)
+        .stream()
+        .map(AlbumChatCommentLikeDetail::new)
+        .collect(Collectors.toList());
+  }
 
-    /**
-     * <p>특정 앨범챗 댓글에 대한 좋아요 목록을 조회합니다.</p>
-     *
-     * @param albumChatCommentId 조회할 댓글 ID
-     * @return 좋아요 목록을 포함한 리스트
-     *
-     * @throws NotFoundAlbumChatCommentException 앨범챗 댓글을 찾을 수 없을 때 발생합니다.
-     */
-    public List<AlbumChatCommentLikeDetail> getAlbumChatCommentLikeByAlbumChatCommentId(Long albumChatCommentId) {
-        if (albumChatCommentRepository.findById(albumChatCommentId).isEmpty()) {
-            throw new NotFoundAlbumChatCommentException();
-        }
-        return albumChatCommentLikeRepository.findByAlbumChatComment_AlbumChatCommentId(albumChatCommentId)
-                .stream()
-                .map(AlbumChatCommentLikeDetail::new)
-                .collect(Collectors.toList());
-    }
+  @Transactional
+  public void like(Long albumChatCommentId, Long userId) {
+    albumChatCommentLikeRepository.save(
+        AlbumChatCommentLike.from(
+            albumChatCommentRepository.findById(albumChatCommentId)
+                .orElseThrow(NotFoundAlbumChatCommentException::new),
+            usersRepository.findById(userId)
+                .orElseThrow(NotFoundUserException::new)
+        )
+    );
+  }
 
-    /**
-     * <p>특정 앨범챗 댓글에 새로운 좋아요를 생성합니다.</p>
-     *
-     * @param userId 좋아요를 생성하는 사용자 ID
-     * @param albumChatCommentId 좋아요를 추가할 댓글 ID
-     * @return 생성된 좋아요 목록을 포함한 리스트
-     *
-     * @throws NotFoundUserException 사용자를 찾을 수 없을 때 발생합니다.
-     * @throws NotFoundAlbumChatCommentException 앨범챗 댓글을 찾을 수 없을 때 발생합니다.
-     * @throws ExistCommentLikeException 이미 존재하는 좋아요가 있을 때 발생합니다.
-     */
-    public List<AlbumChatCommentLikeDetail> albumChatCommentLikeCreate(Long userId, Long albumChatCommentId) {
-        if (albumChatCommentRepository.findById(albumChatCommentId).isEmpty()) {
-            throw new NotFoundAlbumChatCommentException();
-        }
-        if (usersRepository.findByUserId(userId).isEmpty()) {
-            throw new NotFoundUserException();
-        }
-        if (albumChatCommentLikeRepository.findByAlbumChatComment_AlbumChatCommentIdAndUser_UserId(albumChatCommentId, userId).isPresent()) {
-            throw new ExistCommentLikeException();
-        }
-        albumChatCommentLikeRepository.save(AlbumChatCommentLike.builder()
-                .user(usersRepository.findByUserId(userId).get())
-                .albumChatComment(albumChatCommentRepository.findById(albumChatCommentId).get())
-                .build());
-
-        return albumChatCommentLikeRepository.findByAlbumChatComment_AlbumChatCommentId(albumChatCommentId)
-                .stream()
-                .map(AlbumChatCommentLikeDetail::new)
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * <p>특정 앨범챗 댓글에 대한 좋아요를 삭제합니다.</p>
-     *
-     * @param albumChatCommentId 좋아요를 삭제할 댓글 ID
-     * @param userId 좋아요를 삭제하는 사용자 ID
-     * @return 삭제 후 남은 좋아요 목록을 포함한 리스트
-     *
-     * @throws NotFoundCommentLikeException 좋아요를 찾을 수 없을 때 발생합니다.
-     */
-    public List<AlbumChatCommentLikeDetail> albumChatCommentLikeDelete(Long albumChatCommentId, Long userId) {
-        if (albumChatCommentLikeRepository.findByAlbumChatComment_AlbumChatCommentIdAndUser_UserId(albumChatCommentId, userId).isEmpty()) {
-            throw new NotFoundCommentLikeException();
-        }
-        albumChatCommentLikeRepository.deleteByAlbumChatComment_AlbumChatCommentIdAndUser_UserId(albumChatCommentId, userId);
-
-        return albumChatCommentLikeRepository.findByAlbumChatComment_AlbumChatCommentId(albumChatCommentId)
-                .stream()
-                .map(AlbumChatCommentLikeDetail::new)
-                .collect(Collectors.toList());
-    }
-
-    @Transactional
-    public List<AlbumChatCommentLikeDetail> likeOrUnlikeAlbumChat(Long albumChatCommentId, Long userId) {
-        if(albumChatCommentLikeRepository.existsByAlbumChatComment_AlbumChatCommentIdAndUser_UserId(albumChatCommentId, userId)){
-            albumChatCommentLikeRepository.deleteByAlbumChatComment_AlbumChatCommentIdAndUser_UserId(albumChatCommentId, userId);
-        }
-        else{
-            albumChatCommentLikeRepository.save(AlbumChatCommentLike.builder()
-                    .albumChatComment(albumChatCommentRepository.findById(albumChatCommentId).orElseThrow(NotFoundAlbumChatCommentException::new))
-                    .user(usersRepository.findById(userId).orElseThrow(NotFoundUserException::new))
-                    .updateTime(Instant.now())
-                    .build());
-        }
-        albumChatCommentLikeRepository.flush();
-        return albumChatCommentLikeRepository.findByAlbumChatComment_AlbumChatCommentId(albumChatCommentId)
-                .stream()
-                .map(AlbumChatCommentLikeDetail::new)
-                .collect(Collectors.toList());
-    }
+  @Transactional
+  public void unlike(Long albumChatCommentId, Long userId) {
+    AlbumChatCommentLike albumChatcommentLike = albumChatCommentLikeRepository.findByAlbumChatComment_AlbumChatCommentIdAndUser_UserId(
+            albumChatCommentId, userId)
+        .orElseThrow(() -> new NotFoundException("like dont found"));
+    albumChatCommentLikeRepository.delete(albumChatcommentLike);
+  }
 }

--- a/backend/src/main/java/org/cosmic/backend/domain/albumChat/applications/AlbumLikeService.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/albumChat/applications/AlbumLikeService.java
@@ -1,88 +1,56 @@
 package org.cosmic.backend.domain.albumChat.applications;
 
+import lombok.RequiredArgsConstructor;
 import org.cosmic.backend.domain.albumChat.domains.AlbumLike;
-import org.cosmic.backend.domain.albumChat.dtos.albumlike.AlbumChatAlbumLikeDetail;
-import org.cosmic.backend.domain.albumChat.exceptions.ExistAlbumLikeException;
 import org.cosmic.backend.domain.albumChat.exceptions.NotFoundAlbumChatException;
 import org.cosmic.backend.domain.albumChat.repositorys.AlbumLikeRepository;
 import org.cosmic.backend.domain.playList.domains.Album;
 import org.cosmic.backend.domain.playList.exceptions.NotFoundUserException;
 import org.cosmic.backend.domain.playList.repositorys.AlbumRepository;
-import org.cosmic.backend.domain.post.entities.Post;
-import org.cosmic.backend.domain.post.entities.PostLike;
+import org.cosmic.backend.domain.post.dtos.Post.AlbumDetail;
 import org.cosmic.backend.domain.post.exceptions.NotFoundAlbumException;
-import org.cosmic.backend.domain.post.exceptions.NotFoundLikeException;
-import org.cosmic.backend.domain.post.exceptions.NotFoundPostException;
-import org.cosmic.backend.domain.user.domains.User;
 import org.cosmic.backend.domain.user.repositorys.UsersRepository;
+import org.cosmic.backend.globals.exceptions.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * <p>AlbumLikeService 클래스는 앨범 챗의 좋아요 기능과 관련된 비즈니스 로직을 처리합니다.</p>
  *
  * <p>이 서비스는 앨범에 대한 좋아요의 생성, 조회, 삭제 기능을 제공합니다.</p>
- *
  */
 @Service
+@RequiredArgsConstructor
 public class AlbumLikeService {
 
-    private final AlbumLikeRepository likeRepository;
-    private final UsersRepository usersRepository;
-    private final AlbumRepository albumRepository;
+  private final UsersRepository usersRepository;
+  private final AlbumRepository albumRepository;
+  private final AlbumLikeRepository albumLikeRepository;
 
-    /**
-     * <p>AlbumLikeService 생성자입니다.</p>
-     *
-     * @param likeRepository 앨범 좋아요 리포지토리
-     * @param usersRepository 사용자 리포지토리
-     * @param albumRepository 앨범 리포지토리
-     */
-    public AlbumLikeService(AlbumLikeRepository likeRepository, UsersRepository usersRepository, AlbumRepository albumRepository) {
-        this.likeRepository = likeRepository;
-        this.usersRepository = usersRepository;
-        this.albumRepository = albumRepository;
-    }
+  /**
+   * <p>특정 앨범에 대한 좋아요 목록을 조회합니다.</p>
+   *
+   * @param spotifyAlbumId 조회할 앨범의 ID
+   * @return 좋아요 목록을 포함한 리스트
+   * @throws NotFoundAlbumChatException 앨범을 찾을 수 없을 때 발생합니다.
+   */
+  public AlbumDetail getAlbumChatAlbumLikeBySpotifyAlbumId(String spotifyAlbumId) {
+    Album album = albumRepository.findBySpotifyAlbumId(spotifyAlbumId)
+        .orElseThrow(NotFoundAlbumException::new);
+    return AlbumDetail.from(album);
+  }
 
-    /**
-     * <p>특정 앨범에 대한 좋아요 목록을 조회합니다.</p>
-     *
-     * @param albumId 조회할 앨범의 ID
-     * @return 좋아요 목록을 포함한 리스트
-     *
-     * @throws NotFoundAlbumChatException 앨범을 찾을 수 없을 때 발생합니다.
-     */
-    public List<AlbumChatAlbumLikeDetail> getAlbumChatAlbumLikeByAlbumChatId(Long albumId) {
-        if (albumRepository.findById(albumId).isEmpty()) {
-            throw new NotFoundAlbumChatException();
-        }
-        List<AlbumChatAlbumLikeDetail> test=likeRepository.findByAlbum_AlbumId(albumId)
-                .stream()
-                .map(AlbumChatAlbumLikeDetail::new)
-                .collect(Collectors.toList());
-        return test;
-    }
+  @Transactional
+  public void like(String spotifyAlbumId, Long userId) {
+    albumLikeRepository.save(AlbumLike.from(albumRepository.findBySpotifyAlbumId(spotifyAlbumId)
+            .orElseThrow(NotFoundAlbumException::new),
+        usersRepository.findById(userId).orElseThrow(NotFoundUserException::new)));
+  }
 
-    @Transactional
-    public List<AlbumChatAlbumLikeDetail> likeOrUnlikeAlbum(Long albumId, Long userId) {
-        if (likeRepository.existsByAlbum_AlbumIdAndUser_UserId(albumId, userId)) {
-            likeRepository.deleteByAlbum_AlbumIdAndUser_UserId(albumId, userId);
-        }
-        else{
-            likeRepository.save(AlbumLike.builder()
-                    .album(albumRepository.findById(albumId).orElseThrow(NotFoundAlbumException::new))
-                    .user(usersRepository.findById(userId).orElseThrow(NotFoundUserException::new))
-                    .updateTime(Instant.now())
-                    .build());
-        }
-        likeRepository.flush();
-        return likeRepository.findByAlbum_AlbumId(albumId)
-                .stream()
-                .map(AlbumChatAlbumLikeDetail::new)
-                .collect(Collectors.toList());
-    }
+  @Transactional
+  public void unlike(String spotifyAlbumId, Long userId) {
+    AlbumLike albumLike = albumLikeRepository.findByAlbum_SpotifyAlbumIdAndUser_UserId(
+        spotifyAlbumId, userId).orElseThrow(() -> new NotFoundException("not found like"));
+    albumLikeRepository.delete(albumLike);
+  }
 }

--- a/backend/src/main/java/org/cosmic/backend/domain/albumChat/domains/AlbumChatCommentLike.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/albumChat/domains/AlbumChatCommentLike.java
@@ -1,42 +1,54 @@
 package org.cosmic.backend.domain.albumChat.domains;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.cosmic.backend.domain.albumChat.dtos.comment.AlbumChatCommentDetail;
 import org.cosmic.backend.domain.albumChat.dtos.commentlike.AlbumChatCommentLikeDetail;
 import org.cosmic.backend.domain.user.domains.User;
-
-import java.time.Instant;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name="`albumChatCommentLike`")
+@Table(name = "`albumChatCommentLike`")
 @Builder
 @IdClass(AlbumChatCommentLikePK.class)
 public class AlbumChatCommentLike {
 
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "albumChatComment_id")
-    private AlbumChatComment albumChatComment;
+  @Id
+  @ManyToOne
+  @JoinColumn(name = "albumChatComment_id")
+  private AlbumChatComment albumChatComment;
 
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
+  @Id
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  private User user;
 
-    @Column(name = "update_time")
-    private Instant updateTime;
+  @Column(name = "update_time")
+  private Instant updateTime;
 
-    public static AlbumChatCommentLikeDetail toAlbumChatCommentLikeDetail(AlbumChatCommentLike albumChatCommentLike) {
-        return AlbumChatCommentLikeDetail.builder()
-                .author(User.toUserDetail(albumChatCommentLike.user))
-                .updateAt(albumChatCommentLike.updateTime)
-                .build();
-    }
+  public static AlbumChatCommentLikeDetail toAlbumChatCommentLikeDetail(
+      AlbumChatCommentLike albumChatCommentLike) {
+    return AlbumChatCommentLikeDetail.builder()
+        .author(User.toUserDetail(albumChatCommentLike.user))
+        .updateAt(albumChatCommentLike.updateTime)
+        .build();
+  }
+
+  public static AlbumChatCommentLike from(AlbumChatComment albumChatComment, User user) {
+    return AlbumChatCommentLike.builder()
+        .user(user)
+        .albumChatComment(albumChatComment)
+        .build();
+  }
 }

--- a/backend/src/main/java/org/cosmic/backend/domain/albumChat/domains/AlbumLike.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/albumChat/domains/AlbumLike.java
@@ -44,4 +44,11 @@ public class AlbumLike {
         .updateAt(albumLike.updateTime)
         .build();
   }
+
+  public static AlbumLike from(Album album, User user) {
+    return AlbumLike.builder()
+        .album(album)
+        .user(user)
+        .build();
+  }
 }

--- a/backend/src/main/java/org/cosmic/backend/domain/albumChat/repositorys/AlbumLikeRepository.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/albumChat/repositorys/AlbumLikeRepository.java
@@ -1,15 +1,20 @@
 package org.cosmic.backend.domain.albumChat.repositorys;
 
+import java.util.List;
+import java.util.Optional;
 import org.cosmic.backend.domain.albumChat.domains.AlbumLike;
 import org.cosmic.backend.domain.albumChat.domains.AlbumLikePK;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-import java.util.Optional;
-
 public interface AlbumLikeRepository extends JpaRepository<AlbumLike, AlbumLikePK> {
-    List<AlbumLike> findByAlbum_AlbumId(Long albumChatId);
-    Optional<AlbumLike> findByAlbum_AlbumIdAndUser_UserId(Long albumChatId, Long userId);
-    void deleteByAlbum_AlbumIdAndUser_UserId(Long albumId, Long userId);
-    Boolean existsByAlbum_AlbumIdAndUser_UserId(Long postId, Long userId);
+
+  List<AlbumLike> findByAlbum_AlbumId(Long albumChatId);
+
+  Optional<AlbumLike> findByAlbum_AlbumIdAndUser_UserId(Long albumChatId, Long userId);
+
+  void deleteByAlbum_AlbumIdAndUser_UserId(Long albumId, Long userId);
+
+  Boolean existsByAlbum_AlbumIdAndUser_UserId(Long postId, Long userId);
+
+  Optional<AlbumLike> findByAlbum_SpotifyAlbumIdAndUser_UserId(String spotifyAlbumId, Long userId);
 }

--- a/backend/src/main/java/org/cosmic/backend/domain/bestAlbum/apis/BestAlbumApi.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/bestAlbum/apis/BestAlbumApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.transaction.Transactional;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.cosmic.backend.domain.bestAlbum.applications.BestAlbumService;
 import org.cosmic.backend.domain.bestAlbum.dtos.AlbumScoreDto;
 import org.cosmic.backend.domain.bestAlbum.dtos.BestAlbumDetail;
@@ -39,18 +40,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/")
 @ApiCommonResponses
 @Tag(name = "베스트 앨범 관련 API", description = "베스트 앨범 정보 제공 및 저장")
+@RequiredArgsConstructor
 public class BestAlbumApi {
 
   private final BestAlbumService bestAlbumService;
-
-  /**
-   * BestAlbumApi의 생성자.
-   *
-   * @param bestAlbumService 베스트 앨범 서비스 클래스의 인스턴스
-   */
-  public BestAlbumApi(BestAlbumService bestAlbumService) {
-    this.bestAlbumService = bestAlbumService;
-  }
 
   /**
    * <p>특정 유저의 베스트 앨범 목록을 제공합니다.</p>
@@ -73,13 +66,13 @@ public class BestAlbumApi {
   /**
    * <p>특정 유저에게 베스트 앨범을 추가합니다.</p>
    *
-   * @param albumScoreDto 추가할 앨범에 대한 점수 정보
-   * @param albumId       추가할 앨범의 ID
-   * @param userId        유저의 ID
+   * @param albumScoreDto  추가할 앨범에 대한 점수 정보
+   * @param spotifyAlbumId 추가할 앨범의 ID
+   * @param userId         유저의 ID
    * @return 업데이트된 베스트 앨범 목록
    */
   @Transactional
-  @PostMapping("/bestAlbum/{albumId}")
+  @PostMapping("/bestAlbum/{spotifyAlbumId}")
   @ApiResponse(responseCode = "404", description = "Not Found User or Album")
   @ApiResponse(responseCode = "409", description = "Exist BestAlbum")
   @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -89,10 +82,11 @@ public class BestAlbumApi {
       @Parameter(description = "별점")
       @RequestBody AlbumScoreDto albumScoreDto,
       @Parameter(description = "추가할 앨범id")
-      @PathVariable String albumId,
+      @PathVariable String spotifyAlbumId,
       @AuthenticationPrincipal Long userId
   ) {
-    return ResponseEntity.ok(bestAlbumService.add(albumScoreDto.getScore(), userId, albumId));
+    return ResponseEntity.ok(
+        bestAlbumService.add(albumScoreDto.getScore(), userId, spotifyAlbumId));
   }
 
   /**

--- a/backend/src/main/java/org/cosmic/backend/domain/search/apis/SpotifySearchAlbumApi.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/search/apis/SpotifySearchAlbumApi.java
@@ -8,11 +8,10 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.cosmic.backend.domain.auth.applications.CreateSpotifyToken;
 import org.cosmic.backend.domain.search.applications.SearchAlbumService;
 import org.cosmic.backend.domain.search.applications.SearchArtistService;
-import org.cosmic.backend.domain.search.applications.SearchTrackService;
-import org.cosmic.backend.domain.search.dtos.ArtistTrackResponse;
 import org.cosmic.backend.domain.search.dtos.SpotifySearchAlbumResponse;
 import org.cosmic.backend.globals.annotations.ApiCommonResponses;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,59 +22,66 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/")
 @ApiCommonResponses
 @Tag(name = "스포티파이 검색 관련 API", description = "스포티파이를 통한 데이터 검색 제공")
 public class SpotifySearchAlbumApi {
-    @Autowired
-    private SearchAlbumService searchAlbumService;
-    @Autowired
-    private SearchArtistService searchArtistService;
 
-    CreateSpotifyToken createSpotifyToken=new CreateSpotifyToken();
+  CreateSpotifyToken createSpotifyToken = new CreateSpotifyToken();
+  @Autowired
+  private SearchAlbumService searchAlbumService;
+  @Autowired
+  private SearchArtistService searchArtistService;
 
-    // 아티스트 또는 앨범 이름으로 앨범 정보 찾기
-    @GetMapping("/searchSpotify/album/{name}")
-    @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-            array = @ArraySchema(schema = @Schema(implementation = SpotifySearchAlbumResponse.class))))
-    @Operation(summary = "특정 앨범 조회")
-    public ResponseEntity<List<SpotifySearchAlbumResponse>> searchAlbum(
-            @Parameter(description = "앨범 이름")
-            @PathVariable String name) throws JsonProcessingException { //q는 검색어
-        return ResponseEntity.ok(searchAlbumService.searchAlbum(createSpotifyToken.accesstoken(),name));
-    }
+  // 아티스트 또는 앨범 이름으로 앨범 정보 찾기
+  @GetMapping("/searchSpotify/album/{name}")
+  @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+      array = @ArraySchema(schema = @Schema(implementation = SpotifySearchAlbumResponse.class))))
+  @Operation(summary = "특정 앨범 조회")
+  public ResponseEntity<List<SpotifySearchAlbumResponse>> searchAlbum(
+      @Parameter(description = "앨범 이름")
+      @PathVariable String name) throws JsonProcessingException { //q는 검색어
+    return ResponseEntity.ok(
+        searchAlbumService.searchAlbum(createSpotifyToken.accesstoken(), name));
+  }
 
-    //id로 앨범 정보찾기
-    @GetMapping("/searchSpotify/albumId/{albumId}")
-    @ApiResponse(responseCode = "200", content = {@Content(schema=@Schema(contentMediaType = MediaType.APPLICATION_JSON_VALUE
-            ,implementation= SpotifySearchAlbumResponse.class))})
-    @Operation(summary = "특정 앨범 조회")
-    public ResponseEntity<SpotifySearchAlbumResponse> searchAlbumId(
-            @Parameter(description = "앨범 ")
-            @PathVariable String albumId) throws JsonProcessingException { //q는 검색어
-        return ResponseEntity.ok(searchAlbumService.searchAlbumId(createSpotifyToken.accesstoken(),albumId));
-    }
+  //id로 앨범 정보찾기
+  @GetMapping("/searchSpotify/albumId/{spotifyAlbumId}")
+  @ApiResponse(responseCode = "200", content = {
+      @Content(schema = @Schema(contentMediaType = MediaType.APPLICATION_JSON_VALUE
+          , implementation = SpotifySearchAlbumResponse.class))})
+  @Operation(summary = "특정 앨범 조회")
+  public ResponseEntity<SpotifySearchAlbumResponse> searchAlbumId(
+      @Parameter(description = "앨범 id")
+      @PathVariable String spotifyAlbumId) throws JsonProcessingException { //q는 검색어
+    return ResponseEntity.ok(searchAlbumService.searchAlbumId(createSpotifyToken.accesstoken(),
+        spotifyAlbumId));
+  }
 
-    @GetMapping("/searchSpotify/artist/{artistId}/album")
-    @Operation(summary = "특정 아티스트의 앨범들 조회")
-    @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-            array = @ArraySchema(schema = @Schema(implementation = SpotifySearchAlbumResponse.class))))
-    public ResponseEntity<List<SpotifySearchAlbumResponse>> searchAlbumByArtistId(
-            @Parameter(description = "앨범 이름")
-            @PathVariable String artistId) throws JsonProcessingException { //q는 검색어
-        return ResponseEntity.ok(searchArtistService.searchAlbumByArtistId(createSpotifyToken.accesstoken(),artistId));
-    }
-    @GetMapping("/searchSpotify/artist/{artistId}/album/{albumName}")
-    @Operation(summary = "특정 아티스트의 앨범들 조회")
-    @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-            array = @ArraySchema(schema = @Schema(implementation = SpotifySearchAlbumResponse.class))))
-    public ResponseEntity<List<SpotifySearchAlbumResponse>> searchAlbumByArtistIdAndAlbumName(
-            @Parameter(description = "앨범 이름")
-            @PathVariable String artistId,@PathVariable String albumName) throws JsonProcessingException { //q는 검색어
-        return ResponseEntity.ok(searchAlbumService.searchAlbumByArtistIdAndAlbumName(createSpotifyToken.accesstoken(),artistId,albumName));
-    }
+  @GetMapping("/searchSpotify/artist/{spotifyArtistId}/album")
+  @Operation(summary = "특정 아티스트의 앨범들 조회")
+  @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+      array = @ArraySchema(schema = @Schema(implementation = SpotifySearchAlbumResponse.class))))
+  public ResponseEntity<List<SpotifySearchAlbumResponse>> searchAlbumByArtistId(
+      @Parameter(description = "아티스트 ID")
+      @PathVariable String spotifyArtistId) throws JsonProcessingException { //q는 검색어
+    return ResponseEntity.ok(
+        searchArtistService.searchAlbumByArtistId(createSpotifyToken.accesstoken(),
+            spotifyArtistId));
+  }
+
+  @GetMapping("/searchSpotify/artist/{spotifyArtistId}/album/{albumName}")
+  @Operation(summary = "특정 아티스트의 앨범들 조회")
+  @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+      array = @ArraySchema(schema = @Schema(implementation = SpotifySearchAlbumResponse.class))))
+  public ResponseEntity<List<SpotifySearchAlbumResponse>> searchAlbumByArtistIdAndAlbumName(
+      @Parameter(description = "아티스트 ID")
+      @PathVariable String spotifyArtistId, @PathVariable String albumName)
+      throws JsonProcessingException { //q는 검색어
+    return ResponseEntity.ok(
+        searchAlbumService.searchAlbumByArtistIdAndAlbumName(createSpotifyToken.accesstoken(),
+            spotifyArtistId, albumName));
+  }
 
 }

--- a/backend/src/main/java/org/cosmic/backend/domain/search/apis/SpotifySearchTrackApi.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/search/apis/SpotifySearchTrackApi.java
@@ -47,28 +47,29 @@ public class SpotifySearchTrackApi {
         searchTrackService.searchTrack(createSpotifyToken.accesstoken(), name));
   }
 
-  @GetMapping("/searchSpotify/artist/{artistId}/track")
+  @GetMapping("/searchSpotify/artist/{spotifyArtistId}/track")
   @Operation(summary = "특정 아티스트의 노래들 조회")
   @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
       array = @ArraySchema(schema = @Schema(implementation = SpotifySearchTrackResponse.class))))
   public ResponseEntity<List<SpotifySearchTrackResponse>> searchTrackByArtistId(
-      @Parameter(description = "앨범 이름")
-      @PathVariable String artistId) throws JsonProcessingException { //q는 검색어
+      @Parameter(description = "아티스트 Id")
+      @PathVariable String spotifyArtistId) throws JsonProcessingException { //q는 검색어
     return ResponseEntity.ok(
-        searchArtistService.searchTrackByArtistId(createSpotifyToken.accesstoken(), artistId));
+        searchArtistService.searchTrackByArtistId(createSpotifyToken.accesstoken(),
+            spotifyArtistId));
   }
 
-  @GetMapping("/searchSpotify/artist/{artistId}/track/{trackName}")
+  @GetMapping("/searchSpotify/artist/{spotifyArtistId}/track/{trackName}")
   @Operation(summary = "특정 아티스트의 노래들 조회")
   @ApiResponse(responseCode = "200", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
       array = @ArraySchema(schema = @Schema(implementation = ArtistTrackResponse.class))))
   public ResponseEntity<List<ArtistTrackResponse>> searchTrackByArtistIdAndTrackName(
-      @Parameter(description = "앨범 이름")
-      @PathVariable String artistId, @PathVariable String trackName)
+      @Parameter(description = "아티스트 Id")
+      @PathVariable String spotifyArtistId, @PathVariable String trackName)
       throws JsonProcessingException { //q는 검색어
     return ResponseEntity.ok(
         searchTrackService.searchTrackByArtistIdAndTrackName(createSpotifyToken.accesstoken(),
-            artistId, trackName));
+            spotifyArtistId, trackName));
   }
 
 }


### PR DESCRIPTION
1. `/api/album/{albumId}/comment/{albumChatCommentId}/commentLike`,
`/api/album/{spotifyAlbumId}/albumchat`의 DTO 통일
2. spotifyId를 사용하는 API에서는 swagger에서 spotify를 Prefix로 가지고 있도록 변경
3. like 로직 변경