### PR TITLE
hotfix: 부모가 null인 댓글들만 종합해서 activity탭에 보이게 만듦 #124

### DIFF
--- a/backend/src/main/java/org/cosmic/backend/domain/albumChat/dtos/albumChat/AlbumCommentDetail.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/albumChat/dtos/albumChat/AlbumCommentDetail.java
@@ -18,20 +18,10 @@ public class AlbumCommentDetail {//특정 유저가 작성한 앨범챗들.
   AlbumDetail albumDetail;
   AlbumChatCommentDetail albumChatCommentDetail;
 
-  public static AlbumCommentDetail fromNullParentAlbumChat(AlbumChatComment albumChatComment) {
-      if (albumChatComment.getParentAlbumChatComment() == null) {
-        return AlbumCommentDetail.builder()
-                .albumDetail(AlbumDetail.from(albumChatComment.getAlbum()))
-                .albumChatCommentDetail(new AlbumChatCommentDetail(albumChatComment))
-                .build();
-      }
-      return null;  // null 반환
-
-  }
   public static List<AlbumCommentDetail> fromNullParentAlbumChat(List<AlbumChatComment> albumChatComments) {
     return albumChatComments.stream()
             .filter(comment -> comment.getParentAlbumChatComment() == null)  // parent가 null인 경우만 필터링
-            .map(AlbumCommentDetail::fromNullParentAlbumChat)
+            .map(AlbumCommentDetail::from)
             .toList();
   }
   public static AlbumCommentDetail from(AlbumChatComment albumChatComment)

--- a/backend/src/main/java/org/cosmic/backend/domain/albumChat/dtos/albumChat/AlbumCommentDetail.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/albumChat/dtos/albumChat/AlbumCommentDetail.java
@@ -18,14 +18,34 @@ public class AlbumCommentDetail {//특정 유저가 작성한 앨범챗들.
   AlbumDetail albumDetail;
   AlbumChatCommentDetail albumChatCommentDetail;
 
-  public static AlbumCommentDetail from(AlbumChatComment albumChatComment) {
+  public static AlbumCommentDetail fromNullParentAlbumChat(AlbumChatComment albumChatComment) {
+      if (albumChatComment.getParentAlbumChatComment() == null) {
+        return AlbumCommentDetail.builder()
+                .albumDetail(AlbumDetail.from(albumChatComment.getAlbum()))
+                .albumChatCommentDetail(new AlbumChatCommentDetail(albumChatComment))
+                .build();
+      }
+      return null;  // null 반환
+
+  }
+  public static List<AlbumCommentDetail> fromNullParentAlbumChat(List<AlbumChatComment> albumChatComments) {
+    return albumChatComments.stream()
+            .filter(comment -> comment.getParentAlbumChatComment() == null)  // parent가 null인 경우만 필터링
+            .map(AlbumCommentDetail::fromNullParentAlbumChat)
+            .toList();
+  }
+  public static AlbumCommentDetail from(AlbumChatComment albumChatComment)
+  {
     return AlbumCommentDetail.builder()
-        .albumDetail(AlbumDetail.from(albumChatComment.getAlbum()))
-        .albumChatCommentDetail(new AlbumChatCommentDetail(albumChatComment))
-        .build();
+      .albumDetail(AlbumDetail.from(albumChatComment.getAlbum()))
+      .albumChatCommentDetail(new AlbumChatCommentDetail(albumChatComment))
+      .build();
   }
 
   public static List<AlbumCommentDetail> from(List<AlbumChatComment> albumChatComments) {
     return albumChatComments.stream().map(AlbumCommentDetail::from).toList();
   }
+
+
+
 }

--- a/backend/src/main/java/org/cosmic/backend/domain/albumChat/dtos/comment/AlbumChatCommentDetail.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/albumChat/dtos/comment/AlbumChatCommentDetail.java
@@ -33,6 +33,7 @@ public class AlbumChatCommentDetail implements Serializable {
     this.updateAt = albumChatComment.getUpdateTime();
     this.likes = albumChatComment.getAlbumChatCommentLikes().stream()
         .map(a -> UserDetail.from(a.getUser())).toList();
+    this.comments=AlbumChatReplyDetail.from(albumChatComment.getChildComments());
     this.author = User.toUserDetail(albumChatComment.getUser());
   }
 

--- a/backend/src/main/java/org/cosmic/backend/domain/albumScore/apis/AlbumScoreApi.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/albumScore/apis/AlbumScoreApi.java
@@ -1,5 +1,6 @@
 package org.cosmic.backend.domain.albumScore.apis;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.cosmic.backend.domain.albumScore.applications.AlbumScoreService;
 import org.cosmic.backend.domain.albumScore.dtos.AlbumScoreDto;
 import org.cosmic.backend.domain.post.dtos.Post.AlbumDetail;
@@ -11,6 +12,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/")
+@Tag(name = "베스트 앨범 관련 API", description = "베스트 앨범 정보 제공 및 저장")
 public class AlbumScoreApi {
     @Autowired
     private AlbumScoreService albumScoreService;

--- a/backend/src/main/java/org/cosmic/backend/domain/musicProfile/dtos/ActivityDetail.java
+++ b/backend/src/main/java/org/cosmic/backend/domain/musicProfile/dtos/ActivityDetail.java
@@ -20,7 +20,7 @@ public class ActivityDetail {//post와 작성했던 앨범챗들을 가져옴.
   public static ActivityDetail from(User user) {
     return ActivityDetail.builder()
         .albumPostList(PostAndCommentsDetail.from(user.getPosts()))
-        .albumCommentList(AlbumCommentDetail.from(user.getAlbumChatComments()))
+        .albumCommentList(AlbumCommentDetail.fromNullParentAlbumChat(user.getAlbumChatComments()))
         .build();
   }
 }


### PR DESCRIPTION
부모가 null인 앨범챗만 가져오기 완료